### PR TITLE
feat: Add TLS support and additional authentication options for Proxmox Client

### DIFF
--- a/charts/kubemox/templates/deployment.yaml
+++ b/charts/kubemox/templates/deployment.yaml
@@ -52,18 +52,38 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: PROXMOX_IP
-            value: {{ .Values.proxmox.IPAddress }} 
+          - name: PROXMOX_ENDPOINT
+            value: {{ .Values.proxmox.endpoint }} 
+          - name: PROXMOX_INSECURE_SKIP_TLS_VERIFY
+            value: {{ .Values.proxmox.insecureSkipTLSVerify | quote }}
+          {{- if .Values.proxmox.tokenID }}
           - name: PROXMOX_TOKEN_ID
             valueFrom:
               secretKeyRef:
                 name: proxmox-credentials 
-                key: tokenId
+                key: tokenID
+          {{- end }}
+          {{- if .Values.proxmox.secret }}
           - name: PROXMOX_SECRET
             valueFrom:
               secretKeyRef:
                 name: proxmox-credentials 
                 key: secret
+          {{- end }}
+          {{- if .Values.proxmox.username }}
+          - name: PROXMOX_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: proxmox-credentials 
+                key: username
+          {{- end }}
+          {{- if .Values.proxmox.password }}
+          - name: PROXMOX_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: proxmox-credentials 
+                key: password
+          {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/kubemox/templates/secret.yaml
+++ b/charts/kubemox/templates/secret.yaml
@@ -1,7 +1,17 @@
 apiVersion: v1
 data:
+  {{- if .Values.proxmox.secret }}
   secret: {{ .Values.proxmox.secret | b64enc }} 
-  tokenId: {{ .Values.proxmox.tokenId | b64enc }} 
+  {{- end }}
+  {{- if .Values.proxmox.tokenID }}
+  tokenID: {{ .Values.proxmox.tokenID | b64enc }} 
+  {{- end }}
+  {{- if .Values.proxmox.username }}
+  username: {{ .Values.proxmox.username | b64enc }}
+  {{- end }}
+  {{- if .Values.proxmox.password }}
+  password: {{ .Values.proxmox.password | b64enc }}
+  {{- end }}
 kind: Secret
 metadata:
   name: proxmox-credentials

--- a/charts/kubemox/values.yaml
+++ b/charts/kubemox/values.yaml
@@ -5,10 +5,16 @@
 replicaCount: 1
 
 proxmox:
-  IPAddress: "10.0.0.99" 
-  # Those used for authentication on Proxmox
-  tokenId: "root@pam!alp"
+  endpoint: "proxmox.alperen.cloud" 
+  # endpoint: 10.0.0.99
+  # insecureSkipTLSVerify: true
+  insecureSkipTLSVerify: false
+  # Either tokenID/secret or username/password must be set
+  tokenID: "root@pam!alp"
   secret: ""
+  # Both username and password must be set if tokenID/secret is not set
+  username: "root@pam"
+  password: ""
 
 image:
   repository: alperencelik/kubemox 


### PR DESCRIPTION
This commit adds support for TLS verification skipping and additional authentication options for Proxmox. The `PROXMOX_INSECURE_SKIP_TLS_VERIFY` environment variable can be set to skip TLS verification, and the `PROXMOX_TOKEN_ID` and `PROXMOX_SECRET` environment variables can be set to use API token authentication. The `PROXMOX_USERNAME` and `PROXMOX_PASSWORD` environment variables can also be set to use username and password authentication.
