### PR TITLE
Reference serviceAccount by correct name

### DIFF
--- a/charts/kubemox/templates/rolebinding.yaml
+++ b/charts/kubemox/templates/rolebinding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: kubemox 
 subjects:
 - kind: ServiceAccount
-  name: kubemox 
+  name: {{ include "kubemox.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }} 


### PR DESCRIPTION
If you install the chart with any other release name then `kubemox` the default serviceAccoutName will not be kubemox