### PR TITLE
Added existingSecret and extraObjects options to helm chart

### DIFF
--- a/charts/kubemox/templates/deployment.yaml
+++ b/charts/kubemox/templates/deployment.yaml
@@ -52,37 +52,35 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          {{- with .Values.proxmox }}
           - name: PROXMOX_ENDPOINT
-            value: {{ .Values.proxmox.endpoint }} 
+            value: {{ .endpoint }}
           - name: PROXMOX_INSECURE_SKIP_TLS_VERIFY
-            value: {{ .Values.proxmox.insecureSkipTLSVerify | quote }}
-          {{- if .Values.proxmox.tokenID }}
+            value: {{ .insecureSkipTLSVerify | quote }}
           - name: PROXMOX_TOKEN_ID
             valueFrom:
               secretKeyRef:
-                name: proxmox-credentials 
-                key: tokenID
-          {{- end }}
-          {{- if .Values.proxmox.secret }}
+                name: {{ .existingSecret | default "proxmox-credentials" }}
+                key: {{ .tokenIdKey | default "tokenID" }}
+                optional: true
           - name: PROXMOX_SECRET
             valueFrom:
               secretKeyRef:
-                name: proxmox-credentials 
-                key: secret
-          {{- end }}
-          {{- if .Values.proxmox.username }}
+                name: {{ .existingSecret.name | default "proxmox-credentials" }}
+                key: {{ .secretKey | default "secret" }}
+                optional: true
           - name: PROXMOX_USERNAME
             valueFrom:
               secretKeyRef:
-                name: proxmox-credentials 
-                key: username
-          {{- end }}
-          {{- if .Values.proxmox.password }}
+                name: {{ .existingSecret.name | default "proxmox-credentials" }}
+                key: {{ .usernameKey | default "username" }}
+                optional: true
           - name: PROXMOX_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: proxmox-credentials 
-                key: password
+                name: {{ .existingSecret.name | default "proxmox-credentials" }}
+                key: {{ .passwordKey | default "password" }}
+                optional: true
           {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/kubemox/templates/deployment.yaml
+++ b/charts/kubemox/templates/deployment.yaml
@@ -66,19 +66,19 @@ spec:
           - name: PROXMOX_SECRET
             valueFrom:
               secretKeyRef:
-                name: {{ .existingSecret.name | default "proxmox-credentials" }}
+                name: {{ .existingSecret | default "proxmox-credentials" }}
                 key: {{ .secretKey | default "secret" }}
                 optional: true
           - name: PROXMOX_USERNAME
             valueFrom:
               secretKeyRef:
-                name: {{ .existingSecret.name | default "proxmox-credentials" }}
+                name: {{ .existingSecret | default "proxmox-credentials" }}
                 key: {{ .usernameKey | default "username" }}
                 optional: true
           - name: PROXMOX_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: {{ .existingSecret.name | default "proxmox-credentials" }}
+                name: {{ .existingSecret | default "proxmox-credentials" }}
                 key: {{ .passwordKey | default "password" }}
                 optional: true
           {{- end }}

--- a/charts/kubemox/templates/extra-manifests.yaml
+++ b/charts/kubemox/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/charts/kubemox/templates/secret.yaml
+++ b/charts/kubemox/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.proxmox.existingSecret }}
 apiVersion: v1
 data:
   {{- if .Values.proxmox.secret }}
@@ -15,3 +16,4 @@ data:
 kind: Secret
 metadata:
   name: proxmox-credentials
+{{- end }}

--- a/charts/kubemox/values.yaml
+++ b/charts/kubemox/values.yaml
@@ -20,6 +20,17 @@ proxmox:
   # -- Proxmox VE password
   password: "PROXMOX_PASSWORD"
 
+  # # Existing secret containing credentials
+  # existingSecret:
+  # # Key in the secret containing the Proxmox token id
+  # tokenIdKey: tokenID
+  # # Key in the secret containing the Proxmox token secret
+  # secretKey: secret
+  # # Key in the secret containing the Proxmox username
+  # usernameKey: username
+  # # Key in the secret containing the Proxmox password
+  # passwordKey: password
+
 image:
   # -- Kubemox image repository
   repository: alperencelik/kubemox 

--- a/charts/kubemox/values.yaml
+++ b/charts/kubemox/values.yaml
@@ -132,3 +132,17 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# Any additional manifests:
+extraObjects: []
+  # - apiVersion: "external-secrets.io/v1beta1"
+  #   kind: ExternalSecret
+  #   metadata:
+  #     name: kubemox-secrets
+  #   spec:
+  #     secretStoreRef: secret-store
+  #     target:
+  #       name: kubemox-secrets
+  #     dataFrom:
+  #       - extract:
+  #           key: /prod/kubemox


### PR DESCRIPTION
Added option to the helm chart to get credentials from an existing secret and added additional manifests option to allow users to create additional arbitrary resources that could include a secret from an external provider.