### PR TITLE
fix(proxmox): do not retry mutative HTTP methods in RetryRoundTripper

### DIFF
--- a/pkg/proxmox/connection.go
+++ b/pkg/proxmox/connection.go
@@ -226,6 +226,15 @@ type RetryRoundTripper struct {
 }
 
 func (rt *RetryRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Only retry idempotent, safe methods. The Proxmox API uses POST for
+	// create/clone/start/stop/snapshot/delete operations — retrying those
+	// after a connection drop mid-flight can re-submit the request and
+	// spawn duplicate tasks or VMs. GET/HEAD have no side effects and are
+	// always safe to retry on transient transport errors.
+	if !isRetryableMethod(req.Method) {
+		return rt.Transport.RoundTrip(req)
+	}
+
 	var resp *http.Response
 	var err error
 
@@ -235,38 +244,41 @@ func (rt *RetryRoundTripper) RoundTrip(req *http.Request) (*http.Response, error
 			return resp, nil
 		}
 
-		// Check if the error is "server closed idle connection"
-		// This error is safe to retry for idempotent requests,
-		// and also for POSTs if we are sure it happened before the body was sent.
-		// In Go's net/http, this error specifically means the connection was closed by the peer while trying to reuse it.
-		// It is generally safe to retry this specific error.
-		if strings.Contains(err.Error(), "http: server closed idle connection") ||
-			strings.Contains(err.Error(), "EOF") || strings.Contains(err.Error(), "unexpected end of JSON input") {
-			// If we have a body, we might need to rewind it, but GetBody is handled by Request
-			if req.GetBody != nil {
-				newBody, bodyErr := req.GetBody()
-				if bodyErr != nil {
-					return resp, err
-				}
-				req.Body = newBody
-			}
+		// Retry on transient connection errors that occur before the server
+		// processes the request. These are safe to retry for idempotent
+		// methods (guarded above).
+		if isRetriableError(err) {
 			continue
 		}
 
-		// Provide a fallback for connection reset by peer which often happens with Proxmox
-		if strings.Contains(err.Error(), "connection reset by peer") {
-			if req.GetBody != nil {
-				newBody, bodyErr := req.GetBody()
-				if bodyErr != nil {
-					return resp, err
-				}
-				req.Body = newBody
-			}
-			continue
-		}
-
-		// If it's not a retriable error, return immediately
+		// Non-retriable error: return immediately
 		return resp, err
 	}
 	return resp, err
+}
+
+// isRetryableMethod reports whether the HTTP method is safe to retry on
+// transient connection errors. Only idempotent, body-less methods are
+// retried; PVE mutative endpoints (POST/PUT/DELETE/PATCH) must not be
+// retried to avoid duplicate tasks or VMs when the server may have
+// already received and processed the request.
+func isRetryableMethod(method string) bool {
+	return method == http.MethodGet || method == http.MethodHead
+}
+
+// isRetriableError reports whether the transport error is safe to retry
+// for an idempotent request. These errors indicate the connection dropped
+// before or during the request handshake, before the server could act on it.
+func isRetriableError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "http: server closed idle connection") ||
+		strings.Contains(msg, "EOF") ||
+		strings.Contains(msg, "unexpected end of JSON input") ||
+		strings.Contains(msg, "connection reset by peer") {
+		return true
+	}
+	return false
 }

--- a/pkg/proxmox/retry_test.go
+++ b/pkg/proxmox/retry_test.go
@@ -24,45 +24,104 @@ func (m *MockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 func TestRetryRoundTripper(t *testing.T) {
 	tests := []struct {
 		name          string
+		method        string
 		errors        []error
 		expectSuccess bool
 		expectedCalls int
 	}{
 		{
-			name:          "Retry on server closed idle connection",
+			name:          "GET retry on server closed idle connection",
+			method:        http.MethodGet,
 			errors:        []error{errors.New("http: server closed idle connection")},
 			expectSuccess: true,
 			expectedCalls: 2,
 		},
 		{
-			name:          "Retry on EOF",
+			name:          "GET retry on EOF",
+			method:        http.MethodGet,
 			errors:        []error{errors.New("EOF")},
 			expectSuccess: true,
 			expectedCalls: 2,
 		},
 		{
-			name:          "Retry on connection reset by peer",
+			name:          "GET retry on connection reset by peer",
+			method:        http.MethodGet,
 			errors:        []error{errors.New("read: connection reset by peer")},
 			expectSuccess: true,
 			expectedCalls: 2,
 		},
 		{
-			name:          "No retry on unknown error",
+			name:          "HEAD retry on EOF (idempotent, body-less)",
+			method:        http.MethodHead,
+			errors:        []error{errors.New("EOF")},
+			expectSuccess: true,
+			expectedCalls: 2,
+		},
+		{
+			name:          "GET no retry on unknown error",
+			method:        http.MethodGet,
 			errors:        []error{errors.New("unknown error")},
 			expectSuccess: false,
 			expectedCalls: 1,
 		},
 		{
-			name:          "Success on first try",
+			name:          "GET success on first try",
+			method:        http.MethodGet,
 			errors:        []error{},
 			expectSuccess: true,
 			expectedCalls: 1,
 		},
 		{
-			name:          "Fail after max retries",
+			name:          "GET fail after max retries",
+			method:        http.MethodGet,
 			errors:        []error{errors.New("EOF"), errors.New("EOF"), errors.New("EOF"), errors.New("EOF")},
 			expectSuccess: false,
 			expectedCalls: 4, // 1 initial + 3 retries
+		},
+		// Regression guard: PVE uses POST for create/clone/start/stop/snapshot/delete.
+		// Retrying POST after a connection drop can re-submit the request and
+		// spawn duplicate tasks or VMs, so it must NOT retry.
+		{
+			name:          "POST no retry on EOF (mutative)",
+			method:        http.MethodPost,
+			errors:        []error{errors.New("EOF")},
+			expectSuccess: false,
+			expectedCalls: 1,
+		},
+		{
+			name:          "POST no retry on server closed idle connection",
+			method:        http.MethodPost,
+			errors:        []error{errors.New("http: server closed idle connection")},
+			expectSuccess: false,
+			expectedCalls: 1,
+		},
+		{
+			name:          "POST no retry on connection reset by peer",
+			method:        http.MethodPost,
+			errors:        []error{errors.New("connection reset by peer")},
+			expectSuccess: false,
+			expectedCalls: 1,
+		},
+		{
+			name:          "PUT no retry on EOF (mutative config update)",
+			method:        http.MethodPut,
+			errors:        []error{errors.New("EOF")},
+			expectSuccess: false,
+			expectedCalls: 1,
+		},
+		{
+			name:          "DELETE no retry on EOF (mutative)",
+			method:        http.MethodDelete,
+			errors:        []error{errors.New("EOF")},
+			expectSuccess: false,
+			expectedCalls: 1,
+		},
+		{
+			name:          "POST success on first try",
+			method:        http.MethodPost,
+			errors:        []error{},
+			expectSuccess: true,
+			expectedCalls: 1,
 		},
 	}
 
@@ -74,7 +133,7 @@ func TestRetryRoundTripper(t *testing.T) {
 				Retries:   3,
 			}
 
-			req, _ := http.NewRequest("GET", "http://example.com", nil)
+			req, _ := http.NewRequest(tt.method, "http://example.com", nil)
 			resp, err := retryRT.RoundTrip(req)
 
 			if tt.expectSuccess {


### PR DESCRIPTION
## Summary

`RetryRoundTripper` retried all HTTP methods on transient transport errors (`EOF`, `server closed idle connection`, `connection reset by peer`). The Proxmox API uses `POST` for create/clone/start/stop/snapshot/delete operations, so a retry after a connection drop mid-flight could re-submit the request and spawn **duplicate tasks or VMs** in Proxmox.

This change restricts retries to idempotent, body-less methods (`GET`/`HEAD`). `POST`/`PUT`/`DELETE`/`PATCH` now bypass the retry loop entirely and fail fast on the first transport error.

## Why this matters

Before: a connection reset during `qm clone` / `qm create` / `pct create` / `qm snapshot` could cause kubemox to re-submit the request, creating a second VM/container/snapshot that the controller doesn't track — leading to resource leaks and VMID collisions on the Proxmox node.

After: mutative calls fail immediately on transport error; the reconciler requeues and the next attempt either succeeds or hits the existing resource (which is then reconciled idempotently).

## Changes

- `pkg/proxmox/connection.go`: added `isRetryableMethod` + `isRetriableError` helpers; `RoundTrip` early-returns for non-idempotent methods. Removed the now-dead `req.GetBody` body-rewind (only relevant for body-bearing methods, which are no longer retried).
- `pkg/proxmox/retry_test.go`: added `method` field to test cases; added regression-guard cases for `POST`/`PUT`/`DELETE` no-retry behavior on `EOF`/`server closed idle connection`/`connection reset by peer`.

## How I tested

- `go test ./pkg/proxmox/ -run TestRetryRoundTripper -v` → 14/14 pass (was 7)
- `go vet ./pkg/proxmox/`
- `golangci-lint run ./pkg/proxmox/...` → no new findings on changed files
- `go build ./...`
- `go mod verify`

The pre-existing `unused` warnings on other funcs in `connection.go` (`setCachedVMID`, `setCachedVM`, `getCachedVM`) are unrelated to this change.